### PR TITLE
fix: use opaque secret handling by default

### DIFF
--- a/controllers/secret/secret.go
+++ b/controllers/secret/secret.go
@@ -4,8 +4,6 @@
 package secret
 
 import (
-	"fmt"
-
 	"github.com/go-logr/logr"
 	keyhubv1alpha1 "github.com/topicuskeyhub/keyhub-vault-operator/api/v1alpha1"
 	"github.com/topicuskeyhub/keyhub-vault-operator/controllers/vault"

--- a/controllers/secret/secret.go
+++ b/controllers/secret/secret.go
@@ -44,8 +44,6 @@ func (sb *secretBuilder) Build(ks *keyhubv1alpha1.KeyHubSecret, secret *corev1.S
 		secret.Type = corev1.SecretTypeOpaque
 	}
 	switch secret.Type {
-	case corev1.SecretTypeOpaque:
-		return sb.applyOpaqueSecretData(ks, secret)
 	case corev1.SecretTypeBasicAuth:
 		return sb.applyBasicAuthSecretData(ks, secret)
 	case corev1.SecretTypeSSHAuth:
@@ -55,7 +53,7 @@ func (sb *secretBuilder) Build(ks *keyhubv1alpha1.KeyHubSecret, secret *corev1.S
 	case keyhubv1alpha1.SecretTypeApachePasswordFile:
 		return sb.applyApachePasswordFile(ks, secret)
 	default:
-		return fmt.Errorf("Unsupported secret type: %s", secret.Type)
+		return sb.applyOpaqueSecretData(ks, secret)
 	}
 }
 


### PR DESCRIPTION
allow users to construct every secret type not explicitly supported, e.g. `kubernetes.io/dockerconfigjson`