### PR TITLE
Add KeyHub editor and viewer roles to default user-facing roles

### DIFF
--- a/config/rbac/keyhubsecret_editor_role.yaml
+++ b/config/rbac/keyhubsecret_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: keyhubsecret-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
 rules:
 - apiGroups:
   - keyhub.topicus.nl

--- a/config/rbac/keyhubsecret_viewer_role.yaml
+++ b/config/rbac/keyhubsecret_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: keyhubsecret-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - keyhub.topicus.nl


### PR DESCRIPTION
Please see https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles for documentation on these default roles, and what the labels do.

In short: when these KeyHub ClusterRoles are applied on the cluster, the roles are aggregated to the admin + edit roles (keyhubsecret-editor-role) and the view role (keyhubsecret-view-role).